### PR TITLE
Update FF APIs

### DIFF
--- a/libs/firefox-apis.js
+++ b/libs/firefox-apis.js
@@ -52,11 +52,27 @@ function ExtensionSupport (propsChain) {
 }
 
 function i18nSupport (propsChain) {
-    if (propsChain.indexOf("getMessage") === -1) {
-        return new SupportStatus("NO_SUPPORT");
+    var support = [
+        "getMessage",
+    ].join('|');
+
+    var r = new RegExp("^(" + support + ")");
+    if (r.exec(propsChain) !== null) {
+        return new SupportStatus("SUPPORT");
     }
 
-    return new SupportStatus("SUPPORT");
+    var futureSupport = [
+        "getAcceptLanguages",
+        "getUILanguage",
+        "detectLanguage",
+    ].join('|');
+
+    var r2 = new RegExp("^(" + futureSupport + ")");
+    if (r2.exec(propsChain) !== null) {
+        return new SupportStatus("FUTURE_SUPPORT");
+    }
+
+    return new SupportStatus("NO_SUPPORT");
 }
 
 function NotificationsSupport (propsChain) {

--- a/libs/firefox-apis.js
+++ b/libs/firefox-apis.js
@@ -201,7 +201,8 @@ function WebNavigationSupport (propsChain) {
         "getFrame",
         "getAllFrames",
         "onCreatedNavigationTarget",
-        "onHistoryStateUpdated"
+        "onHistoryStateUpdated",
+        "onTabReplaced",
     ].join('|');
 
     var r = new RegExp("^(" + noSupport + ")");

--- a/libs/firefox-apis.js
+++ b/libs/firefox-apis.js
@@ -139,7 +139,7 @@ function RuntimeSupport (propsChain) {
 }
 
 function StorageSupport (propsChain) {
-    if (propsChain.match(/^sync/) !== null) {
+    if (propsChain.match(/^(sync|managed)/) !== null) {
         return new SupportStatus("NO_SUPPORT");
     }
 

--- a/libs/firefox-apis.js
+++ b/libs/firefox-apis.js
@@ -189,6 +189,9 @@ function TabsSupport (propsChain) {
     if (propsChain.indexOf("executeScript") === 0) {
         return new SupportStatus("WARN", "The callback argument is not supported yet.");
     }
+    if (propsChain.indexOf("sendMessage") === 0) {
+        return new SupportStatus("WARN", "The implementation appears to be broken. See bug 1209869.");
+    }
 
     return new SupportStatus("SUPPORT");
 }

--- a/libs/firefox-apis.js
+++ b/libs/firefox-apis.js
@@ -147,7 +147,7 @@ function StorageSupport (propsChain) {
         return new SupportStatus("NO_SUPPORT");
     }
 
-    return new SupportStatus("SUPPORT");
+    return new SupportStatus("WARN", "Not supported in content scripts. See bug 1197346");
 }
 
 function TabsSupport (propsChain) {

--- a/libs/firefox-apis.js
+++ b/libs/firefox-apis.js
@@ -22,11 +22,33 @@ function FullSupport () {
 }
 
 function ExtensionSupport (propsChain) {
-    if (propsChain.match(/^(getBackgroundPage|getURL)/) === null) {
-        return new SupportStatus("NO_SUPPORT");
+    var support = [
+        "getURL",
+        "inIncognitoContex",
+        "getBackgroundPage",
+        "getViews",
+    ].join('|');
+
+    var r = new RegExp("^(" + support + ")");
+
+    if (r.exec(propsChain) !== null) {
+        return new SupportStatus("SUPPORT");
     }
 
-    return new SupportStatus("SUPPORT");
+    var futureSupport = [
+        "isAllowedIncognitoAccess",
+        "isAllowedFileSchemeAccess",
+        "setUpdateUrlData",
+        "lastError",
+    ].join('|');
+
+    var r2 = new RegExp("^(" + futureSupport + ")");
+
+    if (r2.exec(propsChain) !== null) {
+        return new SupportStatus("FUTURE_SUPPORT");
+    }
+
+    return new SupportStatus("NO_SUPPORT");
 }
 
 function i18nSupport (propsChain) {

--- a/libs/firefox-apis.js
+++ b/libs/firefox-apis.js
@@ -39,7 +39,7 @@ function i18nSupport (propsChain) {
 
 function NotificationsSupport (propsChain) {
     if (propsChain.indexOf("create") === 0) {
-        return new SupportStatus("WARN", "The only supported notification options are iconUrl, title, and message.")
+        return new SupportStatus("WARN", "The only supported notification options are iconUrl, title, and message.");
     }
 
     if (propsChain.indexOf("onClosed") === 0) {
@@ -123,7 +123,7 @@ function TabsSupport (propsChain) {
     var r2 = new RegExp("^(" + highlightActive + ")");
 
     if (r2.exec(propsChain) !== null) {
-        return new SupportStatus("WARN", "Highlighted and active are treated as the same since Firefox cannot select multiple tabs.")
+        return new SupportStatus("WARN", "Highlighted and active are treated as the same since Firefox cannot select multiple tabs.");
     }
 
     if (propsChain.indexOf("executeScript") === 0) {

--- a/libs/firefox-apis.js
+++ b/libs/firefox-apis.js
@@ -187,10 +187,7 @@ function TabsSupport (propsChain) {
     }
 
     if (propsChain.indexOf("executeScript") === 0) {
-        return [
-            new SupportStatus("WARN", "The callback argument is not supported yet."),
-            new SupportStatus("WARN", "Host permissions are not enforced yet.")
-        ];
+        return new SupportStatus("WARN", "The callback argument is not supported yet.");
     }
 
     return new SupportStatus("SUPPORT");

--- a/libs/firefox-apis.js
+++ b/libs/firefox-apis.js
@@ -79,25 +79,47 @@ function RuntimeSupport (propsChain) {
     var support = [
         "onStartup",
         "getManifest",
+        "getURL",
         "id",
         "sendMessage",
         "onMessage",
         "onConnect",
-        "connectNative"
+        "connect",
+        "getPlatformInfo",
     ].join('|');
 
     var r = new RegExp("^(" + support + ")");
-    var m = r.exec(propsChain);
-
-    if (m === null) {
-        return new SupportStatus("NO_SUPPORT");
+    if (r.exec(propsChain) !== null) {
+        return new SupportStatus("SUPPORT");
     }
 
-    if (m[0] === "connectNative") {
+    var futureSupport = [
+        "lastError",
+        "getBackgroundPage",
+        "openOptionsPage",
+        "setUninstallURL",
+        "reload",
+        "requestUpdateCheck",
+        "restart",
+        "connectNative",
+        "sendNativeMessage",
+        "getPackageDirectoryEntry",
+        "onInstalled",
+        "onSuspend",
+        "onSuspendCanceled",
+        "onUpdateAvailable",
+        "onBrowserUpdateAvailable",
+        "onConnectExternal",
+        "onMessageExternal",
+        "onRestartRequired",
+    ].join('|');
+
+    var r2 = new RegExp("^(" + futureSupport + ")");
+    if (r2.exec(propsChain) !== null) {
         return new SupportStatus("FUTURE_SUPPORT");
     }
 
-    return new SupportStatus("SUPPORT");
+    return new SupportStatus("NO_SUPPORT");
 }
 
 function StorageSupport (propsChain) {

--- a/libs/firefox-apis.js
+++ b/libs/firefox-apis.js
@@ -1,4 +1,4 @@
-// Processing is done based on the list found at 
+// Processing is done based on the list found at
 // https://wiki.mozilla.org/WebExtensions#List_of_supported_APIs
 
 // Since support of an API is not binary, there is more logic here
@@ -55,18 +55,18 @@ function NotificationsSupport (propsChain) {
 
 function RuntimeSupport (propsChain) {
     var support = [
-        "onStartup", 
-        "getManifest", 
-        "id", 
-        "sendMessage", 
-        "onMessage", 
-        "onConnect", 
+        "onStartup",
+        "getManifest",
+        "id",
+        "sendMessage",
+        "onMessage",
+        "onConnect",
         "connectNative"
     ].join('|');
 
     var r = new RegExp("^(" + support + ")");
     var m = r.exec(propsChain);
-    
+
     if (m === null) {
         return new SupportStatus("NO_SUPPORT");
     }
@@ -92,15 +92,15 @@ function StorageSupport (propsChain) {
 
 function TabsSupport (propsChain) {
     var noSupport = [
-        "sendRequest", 
-        "getSelected", 
-        "duplicate", 
-        "highlight", 
-        "move", 
-        "detectLanguage", 
-        "captureVisibleTab", 
+        "sendRequest",
+        "getSelected",
+        "duplicate",
+        "highlight",
+        "move",
+        "detectLanguage",
+        "captureVisibleTab",
         "getZoom",
-        "setZoom", 
+        "setZoom",
         "getZoomSettings",
         "setZoomSettings"
     ].join('|');
@@ -163,7 +163,7 @@ function WebNavigationSupport (propsChain) {
 function WebRequestSupport (propsChain) {
     var noSupport = [
         "handlerBehaviorChanged",
-        "onAuthRequired", 
+        "onAuthRequired",
         "onBeforeRedirect",
         "onErrorOccurred"
     ].join('|');
@@ -209,7 +209,7 @@ function BookmarksSupport (propsChain) {
     var noSupport = [
         "getRecent",
         "search",
-        "removeTree", 
+        "removeTree",
         "onCreated",
         "onRemoved",
         "onChanged",


### PR DESCRIPTION
I went through http://www.arewewebextensionsyet.com/ and DXR to look for newest developments as of now.

The distinction between `FUTURE_SUPPORT` and `NO_SUPPORT` seems arbitrary in some places.
Perhaps it would be best to blacklist deprecated APIs like `chrome.extension.sendRequest` explicitly instead of letting them 'fall-through'.

Don't hesitate to tell me if you don't like something.
