### PR TITLE
try to recover when manifest parsing fails due to comments in JSON

### DIFF
--- a/libs/ext-converter.js
+++ b/libs/ext-converter.js
@@ -32,7 +32,7 @@ function updateManifest (extensionPath, extensionId, cb) {
             }
             catch (e) {
                 originalError.message = 'Failed to parse manifest.json:\n' + originalError.message;
-                throw originalError;
+                return cb(originalError);
             }
         }
 


### PR DESCRIPTION
it is possible to use comments in manifest.json in chrome
at least in dev mode

however Mozilla devs decided to WONTFIX it:
https://bugzilla.mozilla.org/show_bug.cgi?id=1196283
